### PR TITLE
Include 'prettier' as a dev dependency to ensure providers can be installed 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {},
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",
+    "prettier": "^3.3.3",
     "typescript": "5.6.2"
   },
   "dependencies": {


### PR DESCRIPTION
This is necessary for preventing 'sst add cloudflare' from breaking

Adding cloudflare as a provider breaks because 'prettier' isn't installed as a dev dependency whereas the code inside '.sst' directory necessarily requires it to be installed.